### PR TITLE
Fix NullPointerException in BadWordChecker

### DIFF
--- a/src/main/java/org/example/nodes/utils/BadWordChecker.java
+++ b/src/main/java/org/example/nodes/utils/BadWordChecker.java
@@ -16,6 +16,8 @@ public class BadWordChecker {
     }
 
     public boolean containsBadWords(String content) {
+        if (content == null) return false; // avoid NullPointerException
+
         List<BannedWord> bannedWords = bannedWordService.getActiveBannedWords();
         for (BannedWord word : bannedWords) {
             if (content.toLowerCase().contains(word.getWord().toLowerCase())) {

--- a/src/test/java/org/example/nodes/utils/BadWordCheckerTest.java
+++ b/src/test/java/org/example/nodes/utils/BadWordCheckerTest.java
@@ -1,0 +1,23 @@
+package org.example.nodes.utils;
+
+import org.example.nodes.model.BannedWord;
+import org.example.nodes.service.BannedWordService;
+import org.junit.jupiter.api.Test;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BadWordCheckerTest {
+    @Test
+    void handlesNullContent() {
+        BannedWordService stub = new BannedWordService(null) {
+            @Override
+            public List<BannedWord> getActiveBannedWords() {
+                return Collections.emptyList();
+            }
+        };
+        BadWordChecker checker = new BadWordChecker(stub);
+        assertFalse(checker.containsBadWords(null));
+    }
+}


### PR DESCRIPTION
## Summary
- handle null content in `BadWordChecker.containsBadWords`
- add regression test for null handling

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1a95ae6483209423bc5b4182a868